### PR TITLE
Add announcement GET and DELETE endpoints

### DIFF
--- a/pages/api/announcements.js
+++ b/pages/api/announcements.js
@@ -8,7 +8,7 @@ export default async function handler(req, res) {
       return getAnnouncements(req, res, db);
     }
     case "POST": {
-      return addAnnouncements(req, res, db);
+      return addAnnouncement(req, res, db);
     }
   }
 }
@@ -31,7 +31,7 @@ async function getAnnouncements(req, res, db) {
   }
 }
 
-async function addAnnouncements(req, res, db) {
+async function addAnnouncement(req, res, db) {
   let submission;
   try {
     submission = AnnouncementSubmission.parse(req.body);

--- a/pages/api/announcements/[id].js
+++ b/pages/api/announcements/[id].js
@@ -1,0 +1,81 @@
+const ObjectId = require('mongodb').ObjectId;
+
+const { connectToDatabase } = require("../../../middleware/mongodb");
+import AnnouncementSubmission from "../../../classes/announcementSubmission";
+
+export default async function handler(req, res) {
+  const db = await connectToDatabase();
+  switch (req.method) {
+    case "GET": {
+      return getAnnouncement(req, res, db);
+    }
+    case "DELETE": {
+      return deleteAnnouncement(req, res, db);
+    }
+  }
+}
+
+async function getAnnouncement(req, res, db) {
+  let id;
+  try {
+    id = req.query.id;
+    console.log(`GET ${id}`);
+    id = new ObjectId(id);
+  } catch (err) {
+    return res.status(400).json({
+      message: new Error(err).message,
+      success: false,
+    });
+  }
+  try {
+    const announcement = await db
+      .collection("announcements")
+      .findOne({ _id: id });
+    if (announcement !== null) {
+      return res.status(200).json({
+        data: announcement,
+	success: true,
+      });
+    } else {
+      return res.status(404).json({
+        success: false,
+      });
+    }
+  } catch (err) {
+    return res.status(500).json({
+      message: new Error(err).message,
+      success: false,
+    });
+  }
+}
+
+async function deleteAnnouncement(req, res, db) {
+  let id;
+  try {
+    id = req.query.id;
+    console.log(`DELETE ${id}`);
+    id = new ObjectId(id);
+  } catch (err) {
+    return res.status(400).json({
+      message: new Error(err).message,
+      success: false,
+    });
+  }
+  try {
+    const { deletedCount } = await db.collection("announcements").deleteOne({ _id: id });
+    if (deletedCount > 0) {
+      return res.status(200).json({
+	success: true,
+      });
+    } else {
+      return res.status(404).json({
+        success: false,
+      });
+    }
+  } catch (err) {
+    return res.status(500).json({
+      message: new Error(err).message,
+      success: false,
+    });
+  }
+}


### PR DESCRIPTION
This adds an endpoint at `/api/announcements/[id]` that handles GET and DELETE requests for individual announcements.